### PR TITLE
Hotfixes: misc. bugs when logged in as fietsberaad superadmin (#131)

### DIFF
--- a/src/components/FooterNav.tsx
+++ b/src/components/FooterNav.tsx
@@ -74,7 +74,7 @@ const FooterNav = ({ onStallingAanmelden, children }: {
 
   const navItemsPrimary = [
     // { title: 'Stalling toevoegen' },
-    { title: 'Over Veilig Stallen', url: '/fietsberaad/Copyright' },
+    { title: 'Over VeiligStallen', url: '/fietsberaad/Copyright' },
   ];
 
   const footerMenuItems = getFooter(fietsberaadArticles);
@@ -136,7 +136,7 @@ const FooterNav_overlay = ({ onStallingAanmelden, children }: {
 
   const navItemsPrimary = [
     // { title: 'Stalling toevoegen' },
-    { displayTitle: 'Over Veilig Stallen',   // text in menu
+    { displayTitle: 'Over VeiligStallen',   // text in menu
       municipality: 'fietsberaad',
       Title: 'Copyright' // title in URL
     },

--- a/src/components/beheer/LeftMenuFietsberaad.tsx
+++ b/src/components/beheer/LeftMenuFietsberaad.tsx
@@ -79,7 +79,7 @@ const LeftMenuFietsberaad: React.FC<LeftMenuFietsberaadProps> = ({
           </LeftMenuItem>
         }
 
-        {hasFietsberaadAdmin && 
+        {hasFietsberaadSuperadmin && 
           <LeftMenuItem 
             component={VSMenuTopic.Database} 
             title={'Database'} 
@@ -87,7 +87,7 @@ const LeftMenuFietsberaad: React.FC<LeftMenuFietsberaadProps> = ({
             onSelect={onSelect} />
         }
 
-        { hasAcceptatieOntwikkeling && 
+        {(hasFietsberaadSuperadmin && hasAcceptatieOntwikkeling) && 
           <LeftMenuItem 
             component={false} 
             title={'Ontwikkeling'} compact={false} activecomponent={activecomponent} onSelect={onSelect}>

--- a/src/components/beheer/common/GemeenteFilter.tsx
+++ b/src/components/beheer/common/GemeenteFilter.tsx
@@ -133,7 +133,7 @@ const GemeenteFilter: React.FC<GemeenteFilterProps> = ({
         <CollapsibleContent 
           buttonText="Extra filter opties"
           isOpen={
-            !!filters?.nameFilter ||
+            // !!filters?.nameFilter ||
             filters?.showGemeentenWithoutStallingen !== "yes" ||
             filters?.showGemeentenWithoutUsers !== "yes" ||
             filters?.showGemeentenWithoutExploitanten !== "yes" ||

--- a/src/pages/api/protected/gemeenten/[id].ts
+++ b/src/pages/api/protected/gemeenten/[id].ts
@@ -53,7 +53,7 @@ export default async function handle(
     case "GET": {
       if (id === "new") {
         // add timestamp to the name
-        const defaultRecord = getDefaultNewGemeente('Nieuw ' + new Date().toISOString());
+        const defaultRecord = getDefaultNewGemeente("Data-eigenaar " + new Date().toISOString().slice(0, 16).replace('T', ' '));
         res.status(200).json({data: defaultRecord});
         return;
       }

--- a/src/pages/api/protected/gemeenten/[id]/contactperson.ts
+++ b/src/pages/api/protected/gemeenten/[id]/contactperson.ts
@@ -1,0 +1,121 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from '~/pages/api/auth/[...nextauth]';
+import { prisma } from "~/server/db";
+import { validateUserSession } from "~/utils/server/database-tools";
+import { z } from "zod";
+
+const updateContactPersonSchema = z.object({
+  contactID: z.string().nullable(),
+});
+
+export default async function handle(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user) {
+    console.error("Unauthorized - no session found");
+    res.status(401).json({ error: "Unauthorized - no session found" });
+    return;
+  }
+
+  const id = req.query.id as string;
+  if (!id || id === "new") {
+    res.status(400).json({ error: "Invalid gemeente ID" });
+    return;
+  }
+
+  const validateUserSessionResult = await validateUserSession(session, "any");
+  if ('error' in validateUserSessionResult) {
+    console.error("Unauthorized - invalid session", validateUserSessionResult.error);
+    res.status(401).json({ error: validateUserSessionResult.error });
+    return;
+  }
+
+  // Check if user has access to this gemeente
+  const hasAccess = validateUserSessionResult.sites.includes(id) || 
+                   validateUserSessionResult.activeContactId === id;
+  
+  if (!hasAccess) {
+    console.error("No access to this gemeente", id);
+    res.status(403).json({ error: "No access to this gemeente" });
+    return;
+  }
+
+  switch (req.method) {
+    case "PUT": {
+      try {
+        const parseResult = updateContactPersonSchema.safeParse(req.body);
+        if (!parseResult.success) {
+          console.error("Invalid data format:", parseResult.error);
+          res.status(400).json({ error: "Invalid data format" });
+          return;
+        }
+
+        const { contactID } = parseResult.data;
+
+        // Get the current contact person for this gemeente
+        const currentContact = await prisma.security_users_sites.findFirst({
+          where: {
+            SiteID: id,
+            IsContact: true,
+          },
+        });
+
+        // If there's a current contact person, remove the IsContact flag
+        if (currentContact) {
+          await prisma.security_users_sites.update({
+            where: {
+              ID: currentContact.ID,
+            },
+            data: {
+              IsContact: false,
+            },
+          });
+        }
+
+        // If a new contact person is specified, set the IsContact flag
+        if (contactID) {
+          // Check if the user-site relationship already exists
+          const existingRelation = await prisma.security_users_sites.findFirst({
+            where: {
+              UserID: contactID,
+              SiteID: id,
+            },
+          });
+
+          if (existingRelation) {
+            // Update existing relation
+            await prisma.security_users_sites.update({
+              where: {
+                ID: existingRelation.ID,
+              },
+              data: {
+                IsContact: true,
+              },
+            });
+          } else {
+            // Create new relation
+            await prisma.security_users_sites.create({
+              data: {
+                UserID: contactID,
+                SiteID: id,
+                IsContact: true,
+              },
+            });
+          }
+        }
+
+        res.status(200).json({ success: true });
+      } catch (error) {
+        console.error("Error updating contact person:", error);
+        res.status(500).json({ error: "Error updating contact person" });
+      }
+      break;
+    }
+    default: {
+      res.status(405).json({ error: "Method Not Allowed" });
+    }
+  }
+}

--- a/src/types/contacts.ts
+++ b/src/types/contacts.ts
@@ -100,7 +100,8 @@ export interface VSContactExploitant {
       "ThemeColor1" |
       "ThemeColor2" |
       "CompanyLogo" |
-      "CompanyLogo2"
+      "CompanyLogo2" |
+      "contactID"
   > & {
           isManagingContacts?: {
               ID: number;

--- a/src/types/modules.ts
+++ b/src/types/modules.ts
@@ -32,7 +32,7 @@ export const AVAILABLE_MODULES: VSmodule[] = [
     },
     {
         ID: "veiligstallen",
-        Name: "Veilig Stallen",
+        Name: "VeiligStallen",
         parent: null,
     },
   ]

--- a/src/utils/server/database-tools.ts
+++ b/src/utils/server/database-tools.ts
@@ -68,7 +68,7 @@ export async function validateUserSession(session: any, itemType = "organization
   }
 
   const ownRole = theuser.user_contact_roles.find((role) => role.isOwnOrganization);
-  const isAdminFietsberaad = ownRole && ownRole.ContactID === "1" && [VSUserRoleValuesNew.RootAdmin, VSUserRoleValuesNew.Admin].includes(ownRole.NewRoleID as VSUserRoleValuesNew);
+  const isAdminFietsberaad = ownRole && ownRole.ContactID === "1" && [VSUserRoleValuesNew.RootAdmin, VSUserRoleValuesNew.Viewer].includes(ownRole.NewRoleID as VSUserRoleValuesNew);
 
   if(isAdminFietsberaad===false) {
     // get all distinct contact IDs for the user from the user_contact_role table


### PR DESCRIPTION
* fix #126 Don't show other organisations for Fietsberaad 'admin' role

* Don't show 'Database' and 'Ontwikkeling' for Fietsberaad 'admin' #127 #128

* Veilig Stallen -> VeiligStallen

* Improve default name of new data owner - fixes #129

* Add data owner: Hide "Contactpersoon" field on add, only show on edit

#130

* Don't extend filter options if only Data-eigenaar search term is given

* If data owner edit: Do save contact person and auto select it in <select>