### PR TITLE
docs: Enhance FMS API documentation with authentication details and a…

### DIFF
--- a/scripts/fix-encrypted-password2.ts
+++ b/scripts/fix-encrypted-password2.ts
@@ -1,0 +1,195 @@
+/**
+ * Identify and fix bad `security_users.EncryptedPassword2` entries.
+ *
+ * Background
+ * ----------
+ * The legacy ColdFusion remote.veiligstallen.nl HTTP Basic Auth API authenticates
+ * `security_users` accounts against the SHA-256 hash stored in `EncryptedPassword2`
+ * (NOT the bcrypt hash in `EncryptedPassword`). Users created/edited through the
+ * Next.js UI used to leave `EncryptedPassword2` empty (or, via the password-setup
+ * flow, filled it with a bcrypt hash). Either way those accounts could never
+ * authenticate against the old API.
+ *
+ * What "bad" means here: `EncryptedPassword2` is NULL/empty, or it is not a valid
+ * 64-character hex SHA-256 digest (e.g. it still holds a `$2a$...` bcrypt hash).
+ *
+ * IMPORTANT: bcrypt is a one-way hash, so we CANNOT recompute the correct SHA-256
+ * value without the plaintext password. Instead, this script normalizes broken
+ * values so that the Next.js login flow repopulates them automatically (the login
+ * flow now lazily backfills EncryptedPassword2 on the next successful login).
+ *
+ * Modes:
+ *   1. (default) identify  - list affected accounts, no changes.
+ *   2. --clear-invalid     - null out non-empty *malformed* EncryptedPassword2
+ *                            values so they get repopulated automatically the
+ *                            next time the user logs in via the Next.js app.
+ *
+ * The --clear-invalid mode is DRY-RUN by default. Add --apply to actually write.
+ *
+ * Usage:
+ *   npx tsx scripts/fix-encrypted-password2.ts
+ *   npx tsx scripts/fix-encrypted-password2.ts --clear-invalid
+ *   npx tsx scripts/fix-encrypted-password2.ts --clear-invalid --apply
+ *
+ * Requires: DATABASE_URL in .env, database reachable.
+ */
+
+import { PrismaClient } from "../src/generated/prisma-client";
+import { isValidApiPasswordHash } from "../src/utils/server/password-tools";
+
+const prisma = new PrismaClient();
+
+type Category = "valid" | "empty" | "bcrypt" | "malformed";
+
+const categorize = (value: string | null | undefined): Category => {
+  if (!value) return "empty";
+  if (isValidApiPasswordHash(value)) return "valid";
+  if (/^\$2[aby]\$/.test(value)) return "bcrypt";
+  return "malformed";
+};
+
+type Args = {
+  apply: boolean;
+  clearInvalid: boolean;
+};
+
+const parseArgs = (): Args => {
+  const argv = process.argv.slice(2);
+  const args: Args = { apply: false, clearInvalid: false };
+
+  for (const a of argv) {
+    switch (a) {
+      case "--apply":
+        args.apply = true;
+        break;
+      case "--clear-invalid":
+        args.clearInvalid = true;
+        break;
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return args;
+};
+
+const printHelp = () => {
+  console.log(`
+Fix bad security_users.EncryptedPassword2 entries.
+
+Modes:
+  (no args)             Identify and report affected accounts (read-only)
+  --clear-invalid       Null out non-empty malformed EncryptedPassword2 values
+                        (they self-heal on next Next.js login via backfill)
+
+Flags:
+  --apply               Actually write changes (default is dry-run)
+  -h, --help            Show this help
+`);
+};
+
+const runIdentify = async () => {
+  const users = await prisma.security_users.findMany({
+    select: { UserID: true, UserName: true, DisplayName: true, Status: true, RoleID: true, EncryptedPassword2: true },
+    orderBy: { UserName: "asc" },
+  });
+
+  const counts: Record<Category, number> = { valid: 0, empty: 0, bcrypt: 0, malformed: 0 };
+  const bad: { UserName: string; UserID: string; Status: string | null; RoleID: number | null; category: Category }[] = [];
+
+  for (const u of users) {
+    const cat = categorize(u.EncryptedPassword2);
+    counts[cat] += 1;
+    if (cat !== "valid") {
+      bad.push({ UserName: u.UserName ?? "(no username)", UserID: u.UserID, Status: u.Status, RoleID: u.RoleID, category: cat });
+    }
+  }
+
+  console.log(`\nScanned ${users.length} security_users records.`);
+  console.log(`  valid (SHA-256 hex): ${counts.valid}`);
+  console.log(`  empty/null:          ${counts.empty}`);
+  console.log(`  bcrypt-shaped:       ${counts.bcrypt}`);
+  console.log(`  other malformed:     ${counts.malformed}`);
+
+  if (bad.length === 0) {
+    console.log(`\nAll EncryptedPassword2 entries look valid. Nothing to do.`);
+    return;
+  }
+
+  console.log(`\n${bad.length} account(s) cannot authenticate against the ColdFusion API:\n`);
+  for (const b of bad) {
+    console.log(`  [${b.category.padEnd(9)}] ${b.UserName}  (UserID=${b.UserID}, Status=${b.Status ?? "?"}, RoleID=${b.RoleID ?? "?"})`);
+  }
+
+  console.log(`
+Notes:
+  - bcrypt is one-way, so empty/bcrypt/malformed entries cannot be repaired
+    automatically without the plaintext password.
+  - These accounts will self-heal the next time the user logs in via the
+    Next.js app (login now backfills EncryptedPassword2).
+  - Use --clear-invalid to null out non-empty malformed values so they are in a
+    clean state for that backfill.
+`);
+};
+
+const runClearInvalid = async (apply: boolean) => {
+  const users = await prisma.security_users.findMany({
+    select: { UserID: true, UserName: true, EncryptedPassword2: true },
+  });
+
+  // Only target NON-empty malformed/bcrypt values; empty values are already in
+  // the "needs backfill" state and don't need touching.
+  const targets = users.filter((u) => {
+    const cat = categorize(u.EncryptedPassword2);
+    return cat === "bcrypt" || cat === "malformed";
+  });
+
+  if (targets.length === 0) {
+    console.log(`No non-empty malformed EncryptedPassword2 values found. Nothing to clear.`);
+    return;
+  }
+
+  console.log(`${targets.length} account(s) have a non-empty malformed EncryptedPassword2 that will be cleared (set to ''):\n`);
+  for (const t of targets) {
+    console.log(`  ${t.UserName ?? "(no username)"} (UserID=${t.UserID})`);
+  }
+
+  if (!apply) {
+    console.log(`\nDry-run. Re-run with --apply to clear these values.`);
+    console.log(`After clearing, each account self-heals on its next Next.js login.`);
+    return;
+  }
+
+  let updated = 0;
+  for (const t of targets) {
+    await prisma.security_users.update({
+      where: { UserID: t.UserID },
+      data: { EncryptedPassword2: "" },
+    });
+    updated += 1;
+  }
+  console.log(`\nCleared EncryptedPassword2 for ${updated} account(s). They will self-heal on next login.`);
+};
+
+const main = async () => {
+  const args = parseArgs();
+
+  if (args.clearInvalid) {
+    await runClearInvalid(args.apply);
+  } else {
+    await runIdentify();
+  }
+};
+
+main()
+  .catch((err) => {
+    console.error("Error:", err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    void prisma.$disconnect();
+  });

--- a/src/lib/openapi/fms-api.json
+++ b/src/lib/openapi/fms-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "FMS REST API",
-    "description": "Fietsenstallingen Management Service REST API (V2 en V3)",
+    "description": "Fietsenstallingen Management Service REST API (V2 en V3).\n\n## Toegang (authenticatie)\n\nDe API gebruikt **HTTP Basic Auth**. Endpoints zonder slotje zijn openbaar; endpoints met een slotje vereisen geldige credentials én het juiste recht (`permit`) voor de betreffende stalling.\n\nEr zijn twee soorten accounts:\n\n- **Dataleverancier-/operator-credentials** (per stalling/operator) voor de FMS REST API (v2/v3). Deze worden in FMS beheerd onder *Dataleveranciers* en hebben per stalling een `permit`.\n- **Gebruikersaccounts** (security_users) voor de datastandaard- en rapportage-API, op basis van de rol van de gebruiker.\n\n## Rechten: lezen vs. schrijven\n\nDe FMS REST endpoints hanteren `permit`-niveaus per stalling:\n\n| Permit | Betekenis |\n| --- | --- |\n| `operator` | Alle rechten (lezen én schrijven) |\n| `dataprovider.type1` | Check-ins/check-outs + bezettingsdata |\n| `dataprovider.type2` | Afgeronde transacties + bezettingsdata |\n\n- **Openbaar leesbaar** (geen auth): catalogusdata zoals steden, locaties, secties, plaatsen en abonnementsvormen.\n- **Beschermde velden**: alleen zichtbaar met het `operator`-permit. Zonder permit krijgt u een uitgeklede weergave (geen foutmelding).\n- **Gevoelige reads** (saldi, abonnementen): vereisen het `operator`-permit.\n- **Schrijfacties** (POST/PUT/DELETE): vereisen het `operator`-permit. Uitzonderingen: het synchroniseren van check-ins/check-outs vereist `operator` of `dataprovider.type1`; bezettingsdata (`occupation`) vereist `operator` of `dataprovider.type2`.",
     "version": "1.0.0"
   },
   "servers": [
@@ -156,7 +156,7 @@
     "/v2/setUrlWebserviceForLocker/{bikeparkID}/{sectionID}/{placeID}": {
       "post": {
         "summary": "Callback-URL voor fietskluis instellen",
-        "description": "Zet urlwebservice op een kluisplek. Vereist ENABLE_WRITE_API, superadmin-sessie en operator Basic Auth.\n",
+        "description": "Zet urlwebservice op een kluisplek. Vereist dat ENABLE_WRITE_API aanstaat en operator Basic Auth.\n",
         "tags": [
           "V2 Write"
         ],
@@ -441,7 +441,7 @@
       },
       "post": {
         "summary": "Abonnement toevoegen (operator)",
-        "description": "Vereist ENABLE_WRITE_API en superadmin-sessie naast Basic Auth.",
+        "description": "Vereist dat ENABLE_WRITE_API aanstaat, naast Basic Auth met operator-permit.",
         "tags": [
           "V3 Write"
         ],

--- a/src/lib/openapi/fms-api.yaml
+++ b/src/lib/openapi/fms-api.yaml
@@ -1,7 +1,42 @@
 openapi: 3.0.3
 info:
   title: FMS REST API
-  description: Fietsenstallingen Management Service REST API (V2 en V3)
+  description: |
+    Fietsenstallingen Management Service REST API (V2 en V3).
+
+    ## Toegang (authenticatie)
+
+    De API gebruikt **HTTP Basic Auth**. Endpoints zonder slotje zijn openbaar;
+    endpoints met een slotje vereisen geldige credentials én het juiste recht
+    (`permit`) voor de betreffende stalling.
+
+    Er zijn twee soorten accounts:
+
+    - **Dataleverancier-/operator-credentials** (per stalling/operator) voor de
+      FMS REST API (v2/v3). Deze worden in FMS beheerd onder *Dataleveranciers*
+      en hebben per stalling een `permit`.
+    - **Gebruikersaccounts** (security_users) voor de datastandaard- en
+      rapportage-API, op basis van de rol van de gebruiker.
+
+    ## Rechten: lezen vs. schrijven
+
+    De FMS REST endpoints hanteren `permit`-niveaus per stalling:
+
+    | Permit | Betekenis |
+    | --- | --- |
+    | `operator` | Alle rechten (lezen én schrijven) |
+    | `dataprovider.type1` | Check-ins/check-outs + bezettingsdata |
+    | `dataprovider.type2` | Afgeronde transacties + bezettingsdata |
+
+    - **Openbaar leesbaar** (geen auth): catalogusdata zoals steden, locaties,
+      secties, plaatsen en abonnementsvormen.
+    - **Beschermde velden**: alleen zichtbaar met het `operator`-permit. Zonder
+      permit krijgt u een uitgeklede weergave (geen foutmelding).
+    - **Gevoelige reads** (saldi, abonnementen): vereisen het `operator`-permit.
+    - **Schrijfacties** (POST/PUT/DELETE): vereisen het `operator`-permit.
+      Uitzonderingen: het synchroniseren van check-ins/check-outs vereist
+      `operator` of `dataprovider.type1`; bezettingsdata (`occupation`) vereist
+      `operator` of `dataprovider.type2`.
   version: 1.0.0
 
 servers:
@@ -104,7 +139,7 @@ paths:
     post:
       summary: Callback-URL voor fietskluis instellen
       description: |
-        Zet urlwebservice op een kluisplek. Vereist ENABLE_WRITE_API, superadmin-sessie en operator Basic Auth.
+        Zet urlwebservice op een kluisplek. Vereist dat ENABLE_WRITE_API aanstaat en operator Basic Auth.
       tags: [V2 Write]
       parameters:
         - name: bikeparkID
@@ -275,7 +310,7 @@ paths:
                   $ref: '#/components/schemas/V3SubscriptionEntry'
     post:
       summary: Abonnement toevoegen (operator)
-      description: Vereist ENABLE_WRITE_API en superadmin-sessie naast Basic Auth.
+      description: Vereist dat ENABLE_WRITE_API aanstaat, naast Basic Auth met operator-permit.
       tags: [V3 Write]
       parameters:
         - $ref: '#/components/parameters/V3Citycode'

--- a/src/lib/parking-simulation/fms-api-write-client.ts
+++ b/src/lib/parking-simulation/fms-api-write-client.ts
@@ -3,7 +3,7 @@
  * Used by simulation; credentials from session/settings.
  * Always pass transactionDate from simulation clock.
  *
- * `credentials: "include"` sends the Next-Auth cookie so writes can pass fietsberaad_superadmin checks (when ENABLE_WRITE_API is set).
+ * Writes are authorized purely by Basic Auth (operator/dataprovider permit) plus the ENABLE_WRITE_API kill switch; there is no Next-Auth session requirement. `credentials: "include"` is kept only so any session cookie is forwarded harmlessly.
  */
 
 export interface FmsCredentials {

--- a/src/pages/api/fms/v2/[[...path]].ts
+++ b/src/pages/api/fms/v2/[[...path]].ts
@@ -21,7 +21,7 @@ import { reportOccupationData } from "~/server/services/fms/report-occupation-se
 import { addSubscription, subscribe } from "~/server/services/fms/subscription-service";
 import { logFmsCall } from "~/server/services/fms/webservice-log";
 import * as wachtrijService from "~/server/services/fms/wachtrij-service";
-import { assertFmsWriteAllowedForSession } from "~/server/services/fms/fms-write-policy";
+import { assertFmsWriteApiEnabled } from "~/server/services/fms/fms-write-policy";
 
 function set401(res: NextApiResponse, hadAuthHeader: boolean) {
   if (!hadAuthHeader) {
@@ -101,8 +101,7 @@ export default async function handle(
   }
 
   if (writeMethods.includes(method)) {
-    const writeOk = await assertFmsWriteAllowedForSession(req, res);
-    if (!writeOk) return;
+    if (!assertFmsWriteApiEnabled(res)) return;
   }
 
   try {

--- a/src/pages/api/fms/v3/citycodes/[[...path]].ts
+++ b/src/pages/api/fms/v3/citycodes/[[...path]].ts
@@ -10,7 +10,7 @@ import {
   parseBasicAuth,
   validateFmsAuth,
 } from "~/server/services/fms/fms-auth";
-import { assertFmsWriteAllowedForSession } from "~/server/services/fms/fms-write-policy";
+import { assertFmsWriteApiEnabled } from "~/server/services/fms/fms-write-policy";
 import { parseFieldsQuery } from "~/server/services/fms/fms-v3-fields";
 
 function setCors(res: NextApiResponse) {
@@ -191,8 +191,7 @@ async function handleWrite(
   res: NextApiResponse,
   path: string[]
 ) {
-  const writeOk = await assertFmsWriteAllowedForSession(req, res);
-  if (!writeOk) return;
+  if (!assertFmsWriteApiEnabled(res)) return;
 
   const citycode = path[0];
   if (!citycode) {

--- a/src/pages/api/password-setup/confirm.ts
+++ b/src/pages/api/password-setup/confirm.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import bcrypt from "bcryptjs";
 import { prisma } from "~/server/db";
 import { verifyPasswordSetupToken } from "~/utils/server/password-setup-token";
+import { encryptPasswordForApi } from "~/utils/server/password-tools";
 
 type ConfirmResponse =
   | { ok: true }
@@ -48,7 +49,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   const hashedpassword = await bcrypt.hash(parsed.data.password, saltRounds);
   await prisma.security_users.update({
     where: { UserID: user.UserID },
-    data: { EncryptedPassword: hashedpassword, EncryptedPassword2: hashedpassword },
+    data: {
+      EncryptedPassword: hashedpassword,
+      // ColdFusion remote API Basic Auth checks the SHA-256 hash, not bcrypt.
+      EncryptedPassword2: encryptPasswordForApi(parsed.data.password),
+    },
   });
 
   res.status(200).json({ ok: true });

--- a/src/pages/api/protected/security_users/[id]/index.ts
+++ b/src/pages/api/protected/security_users/[id]/index.ts
@@ -15,6 +15,7 @@ import { userHasRight } from "~/types/utils";
 import { VSSecurityTopic } from "~/types/securityprofile";
 import { getOrganisationTypeByID } from "~/utils/server/database-tools";
 import { syncSecurityUsersSitesFromUserContactRole } from "~/utils/server/user-sync-tools";
+import { encryptPasswordForApi } from "~/utils/server/password-tools";
 
 const saltRounds = 13;
 
@@ -39,6 +40,7 @@ export const securityUserUpdateSchema = securityUserCreateSchema.partial().requi
 const oldSecurityUserCreateSchema = securityUserCreateSchema.omit({password: true, RoleID: true}).extend({
   RoleID: z.nativeEnum(VSUserRoleValues),
   EncryptedPassword: z.string(),
+  EncryptedPassword2: z.string(),
 });
 
 export const oldSecurityUserUpdateSchema = oldSecurityUserCreateSchema.partial().required({UserID: true})
@@ -173,7 +175,8 @@ export default async function handle(
           ParentID: null,
           LastLogin: null,
           Locale: "Dutch (Standard)",
-          EncryptedPassword2: "",
+          // SHA-256 hash required by the ColdFusion remote API Basic Auth.
+          EncryptedPassword2: encryptPasswordForApi(parsed.password),
           Theme: "default",
           SendMailToMailAddress: null
         }
@@ -294,6 +297,8 @@ export default async function handle(
 
         if(parsed.password) {
           updateData.EncryptedPassword = await bcrypt.hash(parsed.password, saltRounds);
+          // Keep the ColdFusion remote API Basic Auth hash in sync.
+          updateData.EncryptedPassword2 = encryptPasswordForApi(parsed.password);
         }
 
         // Rights validation: Updating role is only allowed for gebruikers_dataeigenaar_admin

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -147,15 +147,16 @@ const TestIndexPage: React.FC = () => {
               >
                 FMS API vergelijking
               </Button>
-              <Button
-                onClick={() => handleNavigate('/test/fms-api-docs')}
-                className="py-6 px-8 text-center w-full"
-                style={{ backgroundColor: '#3B82F6' }}
-              >
-                FMS API documentatie (Swagger)
-              </Button>
             </>
           )}
+
+          <Button
+            onClick={() => handleNavigate('/test/fms-api-docs')}
+            className="py-6 px-8 text-center w-full"
+            style={{ backgroundColor: '#3B82F6' }}
+          >
+            FMS API documentatie (Swagger)
+          </Button>
           
         </div>
       </div>

--- a/src/server/services/fms/fms-write-policy.ts
+++ b/src/server/services/fms/fms-write-policy.ts
@@ -1,15 +1,19 @@
 /**
- * FMS REST v2/v3 mutation policy:
- * - `ENABLE_WRITE_API`: must be set to a truthy value (`true`, `1`, `yes`) for mutations to be allowed.
- * - When enabled: writes require a logged-in fietsberaad_superadmin (Next-Auth), plus existing v2 Basic-auth validation.
+ * FMS REST v2/v3 mutation policy.
+ *
+ * - `ENABLE_WRITE_API`: must be set to a truthy value (`true`, `1`, `yes`) for
+ *   mutations to be allowed at all. This is an environment-level kill switch so
+ *   writes can be disabled entirely (e.g. on environments where the FMS write
+ *   API should never run).
+ * - Authorization of writes is handled exactly like the legacy ColdFusion FMS
+ *   REST API: by HTTP Basic Auth on the dataprovider/operator account plus its
+ *   per-stalling `permit` (checked in the route handlers via `validateFmsAuth` /
+ *   `requireV3Auth`). There is intentionally NO Next-Auth session requirement -
+ *   the API is meant to be consumed by machine clients using Basic Auth.
  * - Reads are unchanged (no flag).
  */
 
-import type { NextApiRequest, NextApiResponse } from "next";
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "~/pages/api/auth/[...nextauth]";
-import { VSSecurityTopic } from "~/types/securityprofile";
-import { userHasRight } from "~/types/utils";
+import type { NextApiResponse } from "next";
 
 function isTruthyEnv(value: string | undefined): boolean {
   if (value == null || value === "") return false;
@@ -23,20 +27,15 @@ export function isFmsWriteApiEnabled(): boolean {
 }
 
 /**
- * Require ENABLE_WRITE_API and fietsberaad_superadmin session.
- * @returns false if response was sent
+ * Gate FMS writes on the ENABLE_WRITE_API environment kill switch.
+ * Per-request authorization (Basic Auth + operator/dataprovider permit) is
+ * enforced by the route handlers themselves.
+ *
+ * @returns false if a response (403) was sent
  */
-export async function assertFmsWriteAllowedForSession(
-  req: NextApiRequest,
-  res: NextApiResponse
-): Promise<boolean> {
+export function assertFmsWriteApiEnabled(res: NextApiResponse): boolean {
   if (!isFmsWriteApiEnabled()) {
     res.status(403).json({ message: "FMS write API is disabled", status: 0 });
-    return false;
-  }
-  const session = await getServerSession(req, res, authOptions);
-  if (!session?.user?.securityProfile || !userHasRight(session.user.securityProfile, VSSecurityTopic.fietsberaad_superadmin)) {
-    res.status(403).json({ message: "Forbidden", status: 0 });
     return false;
   }
   return true;

--- a/src/utils/auth-tools.ts
+++ b/src/utils/auth-tools.ts
@@ -13,8 +13,9 @@ import {
 import { createSecurityProfile } from "~/utils/server/securitycontext";
 import { checkToken, checkMagicLinkToken } from "~/utils/token-tools";
 import { getOrganisationTypeByID } from "~/utils/server/database-tools";
+import { encryptPasswordForApi, isValidApiPasswordHash } from "~/utils/server/password-tools";
 
-type OrgAccountData = Pick<security_users, "UserID" | "DisplayName" | "UserName" | "GroupID" | "ParentID" | "SiteID" | "EncryptedPassword"> & {
+type OrgAccountData = Pick<security_users, "UserID" | "DisplayName" | "UserName" | "GroupID" | "ParentID" | "SiteID" | "EncryptedPassword" | "EncryptedPassword2"> & {
   user_contact_roles: { 
     ContactID: string;
     isOwnOrganization: boolean;
@@ -90,6 +91,7 @@ export const getUserFromCredentials = async (
         DisplayName: true,
         UserName: true,
         EncryptedPassword: true,
+        EncryptedPassword2: true,
         user_contact_roles: {
           select: {
             ContactID: true,
@@ -106,6 +108,21 @@ export const getUserFromCredentials = async (
       orgaccount.EncryptedPassword !== null
     ) {
       if (await bcrypt.compare(password, orgaccount.EncryptedPassword)) {
+        // Lazily backfill the ColdFusion remote API hash (EncryptedPassword2)
+        // when it is missing or malformed. This mirrors the legacy
+        // UserSession.cfc behaviour and lets pre-existing accounts self-heal on
+        // their next successful login. We have the plaintext password here, so
+        // we can compute the correct SHA-256 hash.
+        if (!isValidApiPasswordHash(orgaccount.EncryptedPassword2)) {
+          try {
+            await prisma.security_users.update({
+              where: { UserID: orgaccount.UserID },
+              data: { EncryptedPassword2: encryptPasswordForApi(password) },
+            });
+          } catch (backfillError) {
+            console.error("### getUserFromCredentials - failed to backfill EncryptedPassword2", backfillError);
+          }
+        }
         const profileUserAccount = await getProfileUser(orgaccount);
         if (profileUserAccount) {
           return profileUserAccount;

--- a/src/utils/server/password-tools.ts
+++ b/src/utils/server/password-tools.ts
@@ -1,0 +1,38 @@
+/*
+  Password helpers shared between the web login and the legacy ColdFusion
+  remote.veiligstallen.nl HTTP Basic Auth API.
+
+  The security_users table stores TWO password hashes:
+    - EncryptedPassword  : bcrypt hash, used for interactive (web) login
+    - EncryptedPassword2 : SHA-256 hash, used by the ColdFusion API Basic Auth
+                           (bcrypt is too slow to run on every API call)
+
+  ColdFusion fills EncryptedPassword2 via helperclass.encrypt():
+      Hash(str, "SHA-256")
+  which returns an UPPERCASE hex digest. We replicate that exact format here so
+  the values are byte-identical to records created by the old system.
+*/
+import { createHash } from "crypto";
+
+/**
+ * Produce the SHA-256 hash for security_users.EncryptedPassword2 in the exact
+ * format used by ColdFusion (`Hash(str, "SHA-256")`): uppercase hex.
+ *
+ * Note: MySQL's default collation is case-insensitive, so the API comparison
+ * would also match lowercase, but we use uppercase to stay identical to the
+ * legacy data.
+ */
+export const encryptPasswordForApi = (password: string): string => {
+  return createHash("sha256").update(password, "utf8").digest("hex").toUpperCase();
+};
+
+/**
+ * Returns true when the given EncryptedPassword2 value is a valid ColdFusion
+ * API hash, i.e. a 64-character hex SHA-256 digest. Empty values, bcrypt hashes
+ * (`$2a$...`) and any other malformed content are considered invalid and will
+ * never match the ColdFusion Basic Auth query.
+ */
+export const isValidApiPasswordHash = (value: string | null | undefined): boolean => {
+  if (!value) return false;
+  return /^[0-9a-fA-F]{64}$/.test(value);
+};


### PR DESCRIPTION
…ccess rights

- Updated the API description to include detailed authentication methods and account types.
- Clarified access rights for reading and writing operations, including permit levels.
- Adjusted endpoint descriptions to specify requirements for Basic Auth and the ENABLE_WRITE_API setting.
- Refactored write policy to remove Next-Auth session dependency, focusing solely on Basic Auth and permit checks.